### PR TITLE
NuGet restore fix and some cosmetic stuff

### DIFF
--- a/NetMQ.ReactiveExtensions.SamplePublisher/NetMQ.ReactiveExtensions.SamplePublisher.csproj
+++ b/NetMQ.ReactiveExtensions.SamplePublisher/NetMQ.ReactiveExtensions.SamplePublisher.csproj
@@ -83,17 +83,17 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Rx-Core.2.2.5\lib\net40\System.Reactive.Core.dll</HintPath>
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\net40\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Rx-Interfaces.2.2.5\lib\net40\System.Reactive.Interfaces.dll</HintPath>
+      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net40\System.Reactive.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/NetMQ.ReactiveExtensions.SampleSubscriber/NetMQ.ReactiveExtensions.SampleSubscriber.csproj
+++ b/NetMQ.ReactiveExtensions.SampleSubscriber/NetMQ.ReactiveExtensions.SampleSubscriber.csproj
@@ -88,17 +88,17 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Rx-Core.2.2.5\lib\net40\System.Reactive.Core.dll</HintPath>
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\net40\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Rx-Interfaces.2.2.5\lib\net40\System.Reactive.Interfaces.dll</HintPath>
+      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net40\System.Reactive.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/NetMQ.ReactiveExtensions.Tests/NetMQ.ReactiveExtensions.Tests.csproj
+++ b/NetMQ.ReactiveExtensions.Tests/NetMQ.ReactiveExtensions.Tests.csproj
@@ -81,9 +81,9 @@
       <HintPath>..\packages\NetMQ.3.3.3-rc4\lib\net40\NetMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
       <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
@@ -92,11 +92,11 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Rx-Core.2.2.5\lib\net40\System.Reactive.Core.dll</HintPath>
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\net40\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Rx-Interfaces.2.2.5\lib\net40\System.Reactive.Interfaces.dll</HintPath>
+      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net40\System.Reactive.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -117,9 +117,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="NetMQ.ReactiveExtensions.Tests.cs" />
-    <None Include="packages.config" />
     <Compile Include="SerializeAnExceptionTests.cs" />
     <Compile Include="SerializeViaProtoBufTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/NetMQ.ReactiveExtensions/NetMQ.ReactiveExtensions.cs
+++ b/NetMQ.ReactiveExtensions/NetMQ.ReactiveExtensions.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Threading;
 using NetMQ.Monitoring;
 using NetMQ.Sockets;
-using ProtoBuf;
 // ReSharper disable SuggestVarOrType_SimpleTypes
 // ReSharper disable InvertIf
 #pragma warning disable 649
@@ -26,6 +25,7 @@ namespace NetMQ.ReactiveExtensions
 	/// <threadSafe>Yes</threadSafe>
 	public class SubjectNetMQ<T> : IObservable<T>, IObserver<T>, IDisposable
 	{
+	    // ReSharper disable once NotAccessedField.Local
 		private readonly EnumWhenToCreateConnection m_whenToCreateConnection;
 		private CancellationTokenSource m_cancellationTokenSource;
 		public string QueueName { get; private set; }
@@ -106,7 +106,7 @@ namespace NetMQ.ReactiveExtensions
 						{
 							monitor.Accepted -= Publisher_Event_Accepted;
 							monitor.Listening -= Publisher_Event_Listening;
-							// Current issue with NegMQ: Cannot stop or dipose monitor, or else it stops the parent socket.
+							// Current issue with NegMQ: Cannot stop or dispose monitor, or else it stops the parent socket.
 							//monitor.Stop();
 							//monitor.Dispose();
 						}
@@ -202,7 +202,7 @@ namespace NetMQ.ReactiveExtensions
 											{
 												m_subscribers.ForEach(o => o.OnCompleted());
 
-												// We are done! We want to send any more messages to subscribers, and we
+												// We are done! We don't want to send any more messages to subscribers, and we
 												// want to close the listening socket.
 												m_cancellationTokenSource.Cancel();
 											}
@@ -282,7 +282,7 @@ namespace NetMQ.ReactiveExtensions
 							monitor.ConnectRetried -= Subscriber_Event_ConnectRetried;
 							monitor.Connected -= Subscriber_Event_Connected;
 
-							// Issue with NetMQ - cannot .Stop or .Dispose, or else it will dipsose of the parent socket.
+							// Issue with NetMQ - cannot .Stop or .Dispose, or else it will dispose of the parent socket.
 							//monitor.Stop();
 							//monitor.Dispose();
 						}

--- a/NetMQ.ReactiveExtensions/NetMQ.ReactiveExtensions.csproj
+++ b/NetMQ.ReactiveExtensions/NetMQ.ReactiveExtensions.csproj
@@ -84,17 +84,18 @@
       <HintPath>..\packages\NetMQ.3.3.3-rc4\lib\net40\NetMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="protobuf-net">
-      <HintPath>..\..\..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Rx-Core.2.2.5\lib\net40\System.Reactive.Core.dll</HintPath>
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\net40\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Rx-Interfaces.2.2.5\lib\net40\System.Reactive.Interfaces.dll</HintPath>
+      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net40\System.Reactive.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/NetMQ.ReactiveExtensions/SerializeAnException.cs
+++ b/NetMQ.ReactiveExtensions/SerializeAnException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;


### PR DESCRIPTION
The NuGet changes are curious. Apparently your packages directory was 2 levels above the one I got with my clone of this project.

Other tiny changes are minor, I think.
Line 205 of NetMQ.ReactiveExtensions.cs, though, I added the word "don't". I hope that's right.

This is a *_really *_nice addition to NetMQ, IMHO.
