### PR TITLE
Should now be compatible with .NET Core 1.0 + .NET 4.5.

### DIFF
--- a/NetMQ.ReactiveExtensions.SamplePublisher/App.config
+++ b/NetMQ.ReactiveExtensions.SamplePublisher/App.config
@@ -1,15 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="AsyncIO" publicKeyToken="44a94435bd6f33f8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.1.25.0" newVersion="0.1.25.0" />
+        <assemblyIdentity name="AsyncIO" publicKeyToken="44a94435bd6f33f8" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-0.1.25.0" newVersion="0.1.25.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>
-

--- a/NetMQ.ReactiveExtensions.SamplePublisher/NetMQ.ReactiveExtensions.SamplePublisher.csproj
+++ b/NetMQ.ReactiveExtensions.SamplePublisher/NetMQ.ReactiveExtensions.SamplePublisher.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NetMQ.ReactiveExtensions.SampleServer</RootNamespace>
     <AssemblyName>NetMQ.ReactiveExtensions.SampleServer</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,6 +33,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -87,13 +89,21 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rx-Core.2.2.5\lib\net40\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Reactive.Core, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Core.3.1.0\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net40\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Interfaces.3.1.0\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ServiceModel" />

--- a/NetMQ.ReactiveExtensions.SamplePublisher/Properties/AssemblyInfo.cs
+++ b/NetMQ.ReactiveExtensions.SamplePublisher/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.4.0")]
-[assembly: AssemblyFileVersion("0.9.4.0")]
+[assembly: AssemblyVersion("0.9.4.2")]
+[assembly: AssemblyFileVersion("0.9.4.2")]

--- a/NetMQ.ReactiveExtensions.SamplePublisher/packages.config
+++ b/NetMQ.ReactiveExtensions.SamplePublisher/packages.config
@@ -1,8 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncIO" version="0.1.26.0" targetFramework="net40" />
+  <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net45" />
   <package id="NetMQ" version="4.0.0-rc5" targetFramework="net40" />
-  <package id="protobuf-net" version="2.1.0" targetFramework="net40" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net40" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net40" />
+  <package id="NETStandard.Library" version="1.6.0" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net40" requireReinstallation="true" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net45" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net45" />
+  <package id="System.ComponentModel" version="4.0.1" targetFramework="net45" />
+  <package id="System.Diagnostics.Contracts" version="4.0.1" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net45" />
+  <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="net45" />
+  <package id="System.Diagnostics.Tracing" version="4.1.0" targetFramework="net45" />
+  <package id="System.Dynamic.Runtime" version="4.0.11" targetFramework="net45" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net45" />
+  <package id="System.IO" version="4.1.0" targetFramework="net45" />
+  <package id="System.IO.Compression" version="4.1.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net45" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.1.0" targetFramework="net45" />
+  <package id="System.Net.Primitives" version="4.0.11" targetFramework="net45" />
+  <package id="System.ObjectModel" version="4.0.12" targetFramework="net45" />
+  <package id="System.Reactive.Core" version="3.1.0" targetFramework="net45" />
+  <package id="System.Reactive.Interfaces" version="3.1.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net45" />
+  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net45" />
+  <package id="System.Reflection.Primitives" version="4.0.1" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net45" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net45" />
+  <package id="System.Runtime.Numerics" version="4.0.1" targetFramework="net45" />
+  <package id="System.Text.Encoding" version="4.0.11" targetFramework="net45" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net45" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net45" />
+  <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net45" />
 </packages>

--- a/NetMQ.ReactiveExtensions.SampleSubscriber/App.config
+++ b/NetMQ.ReactiveExtensions.SampleSubscriber/App.config
@@ -1,13 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="AsyncIO" publicKeyToken="44a94435bd6f33f8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.1.25.0" newVersion="0.1.25.0" />
+        <assemblyIdentity name="AsyncIO" publicKeyToken="44a94435bd6f33f8" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-0.1.25.0" newVersion="0.1.25.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/NetMQ.ReactiveExtensions.SampleSubscriber/NetMQ.ReactiveExtensions.SampleSubscriber.csproj
+++ b/NetMQ.ReactiveExtensions.SampleSubscriber/NetMQ.ReactiveExtensions.SampleSubscriber.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NetMQ.ReactiveExtensions.SampleClient</RootNamespace>
     <AssemblyName>NetMQ.ReactiveExtensions.SampleClient</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -92,13 +92,21 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rx-Core.2.2.5\lib\net40\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Reactive.Core, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Core.3.1.0\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net40\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Interfaces.3.1.0\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ServiceModel" />

--- a/NetMQ.ReactiveExtensions.SampleSubscriber/Properties/AssemblyInfo.cs
+++ b/NetMQ.ReactiveExtensions.SampleSubscriber/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.4.0")]
-[assembly: AssemblyFileVersion("0.9.4.0")]
+[assembly: AssemblyVersion("0.9.4.2")]
+[assembly: AssemblyFileVersion("0.9.4.2")]

--- a/NetMQ.ReactiveExtensions.SampleSubscriber/packages.config
+++ b/NetMQ.ReactiveExtensions.SampleSubscriber/packages.config
@@ -1,8 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncIO" version="0.1.26.0" targetFramework="net40" />
+  <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net45" />
   <package id="NetMQ" version="4.0.0-rc5" targetFramework="net40" />
-  <package id="protobuf-net" version="2.1.0" targetFramework="net40" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net40" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net40" />
+  <package id="NETStandard.Library" version="1.6.0" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net40" requireReinstallation="true" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net45" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net45" />
+  <package id="System.ComponentModel" version="4.0.1" targetFramework="net45" />
+  <package id="System.Diagnostics.Contracts" version="4.0.1" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net45" />
+  <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="net45" />
+  <package id="System.Diagnostics.Tracing" version="4.1.0" targetFramework="net45" />
+  <package id="System.Dynamic.Runtime" version="4.0.11" targetFramework="net45" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net45" />
+  <package id="System.IO" version="4.1.0" targetFramework="net45" />
+  <package id="System.IO.Compression" version="4.1.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net45" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.1.0" targetFramework="net45" />
+  <package id="System.Net.Primitives" version="4.0.11" targetFramework="net45" />
+  <package id="System.ObjectModel" version="4.0.12" targetFramework="net45" />
+  <package id="System.Reactive.Core" version="3.1.0" targetFramework="net45" />
+  <package id="System.Reactive.Interfaces" version="3.1.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net45" />
+  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net45" />
+  <package id="System.Reflection.Primitives" version="4.0.1" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net45" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net45" />
+  <package id="System.Runtime.Numerics" version="4.0.1" targetFramework="net45" />
+  <package id="System.Text.Encoding" version="4.0.11" targetFramework="net45" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net45" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net45" />
+  <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net45" />
 </packages>

--- a/NetMQ.ReactiveExtensions.Tests/NetMQ.ReactiveExtensions.Tests.csproj
+++ b/NetMQ.ReactiveExtensions.Tests/NetMQ.ReactiveExtensions.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NetMQ.ReactiveExtensions.Tests</RootNamespace>
     <AssemblyName>NetMQ.ReactiveExtensions.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -90,13 +90,21 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rx-Core.2.2.5\lib\net40\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Reactive.Core, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Core.3.1.0\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net40\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Interfaces.3.1.0\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ServiceModel" />

--- a/NetMQ.ReactiveExtensions.Tests/Properties/AssemblyInfo.cs
+++ b/NetMQ.ReactiveExtensions.Tests/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.9.4.0")]
-[assembly: AssemblyFileVersion("0.9.4.0")]
+[assembly: AssemblyVersion("0.9.4.2")]
+[assembly: AssemblyFileVersion("0.9.4.2")]

--- a/NetMQ.ReactiveExtensions.Tests/app.config
+++ b/NetMQ.ReactiveExtensions.Tests/app.config
@@ -1,12 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="AsyncIO" publicKeyToken="44a94435bd6f33f8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.1.25.0" newVersion="0.1.25.0" />
+        <assemblyIdentity name="AsyncIO" publicKeyToken="44a94435bd6f33f8" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-0.1.25.0" newVersion="0.1.25.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/NetMQ.ReactiveExtensions.Tests/packages.config
+++ b/NetMQ.ReactiveExtensions.Tests/packages.config
@@ -1,9 +1,43 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncIO" version="0.1.26.0" targetFramework="net40" />
+  <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net45" />
   <package id="NetMQ" version="4.0.0-rc5" targetFramework="net40" />
+  <package id="NETStandard.Library" version="1.6.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
-  <package id="protobuf-net" version="2.1.0" targetFramework="net40" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net40" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net40" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net40" requireReinstallation="true" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net45" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net45" />
+  <package id="System.ComponentModel" version="4.0.1" targetFramework="net45" />
+  <package id="System.Diagnostics.Contracts" version="4.0.1" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net45" />
+  <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="net45" />
+  <package id="System.Diagnostics.Tracing" version="4.1.0" targetFramework="net45" />
+  <package id="System.Dynamic.Runtime" version="4.0.11" targetFramework="net45" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net45" />
+  <package id="System.IO" version="4.1.0" targetFramework="net45" />
+  <package id="System.IO.Compression" version="4.1.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net45" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.1.0" targetFramework="net45" />
+  <package id="System.Net.Primitives" version="4.0.11" targetFramework="net45" />
+  <package id="System.ObjectModel" version="4.0.12" targetFramework="net45" />
+  <package id="System.Reactive.Core" version="3.1.0" targetFramework="net45" />
+  <package id="System.Reactive.Interfaces" version="3.1.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net45" />
+  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net45" />
+  <package id="System.Reflection.Primitives" version="4.0.1" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net45" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net45" />
+  <package id="System.Runtime.Numerics" version="4.0.1" targetFramework="net45" />
+  <package id="System.Text.Encoding" version="4.0.11" targetFramework="net45" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net45" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net45" />
+  <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net45" />
 </packages>

--- a/NetMQ.ReactiveExtensions/Git Sync To Master.bat
+++ b/NetMQ.ReactiveExtensions/Git Sync To Master.bat
@@ -1,0 +1,2 @@
+rem If this has already been done, then it's ok.
+git remote add upstream https://github.com/NetMQ/NetMQ.ReactiveExtensions

--- a/NetMQ.ReactiveExtensions/NetMQ.ReactiveExtensions.csproj
+++ b/NetMQ.ReactiveExtensions/NetMQ.ReactiveExtensions.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NetMQ.ReactiveExtensions</RootNamespace>
     <AssemblyName>NetMQ.ReactiveExtensions</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -90,13 +90,21 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rx-Core.2.2.5\lib\net40\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Reactive.Core, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Core.3.1.0\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net40\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Interfaces.3.1.0\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ServiceModel" />

--- a/NetMQ.ReactiveExtensions/Properties/AssemblyInfo.cs
+++ b/NetMQ.ReactiveExtensions/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.4.0")]
-[assembly: AssemblyFileVersion("0.9.4.0")]
+[assembly: AssemblyVersion("0.9.4.2")]
+[assembly: AssemblyFileVersion("0.9.4.2")]

--- a/NetMQ.ReactiveExtensions/SubjectNetMQ.cs
+++ b/NetMQ.ReactiveExtensions/SubjectNetMQ.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reactive;
 using System.Threading;
 using NetMQ.Monitoring;
 using NetMQ.Sockets;

--- a/NetMQ.ReactiveExtensions/app.config
+++ b/NetMQ.ReactiveExtensions/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="AsyncIO" publicKeyToken="44a94435bd6f33f8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.1.25.0" newVersion="0.1.25.0" />
+        <assemblyIdentity name="AsyncIO" publicKeyToken="44a94435bd6f33f8" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-0.1.25.0" newVersion="0.1.25.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/NetMQ.ReactiveExtensions/packages.config
+++ b/NetMQ.ReactiveExtensions/packages.config
@@ -1,8 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncIO" version="0.1.26.0" targetFramework="net40" />
+  <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net45" />
   <package id="NetMQ" version="4.0.0-rc5" targetFramework="net40" />
-  <package id="protobuf-net" version="2.1.0" targetFramework="net40" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net40" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net40" />
+  <package id="NETStandard.Library" version="1.6.0" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net40" requireReinstallation="true" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net45" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net45" />
+  <package id="System.ComponentModel" version="4.0.1" targetFramework="net45" />
+  <package id="System.Diagnostics.Contracts" version="4.0.1" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net45" />
+  <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="net45" />
+  <package id="System.Diagnostics.Tracing" version="4.1.0" targetFramework="net45" />
+  <package id="System.Dynamic.Runtime" version="4.0.11" targetFramework="net45" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net45" />
+  <package id="System.IO" version="4.1.0" targetFramework="net45" />
+  <package id="System.IO.Compression" version="4.1.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net45" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.1.0" targetFramework="net45" />
+  <package id="System.Net.Primitives" version="4.0.11" targetFramework="net45" />
+  <package id="System.ObjectModel" version="4.0.12" targetFramework="net45" />
+  <package id="System.Reactive.Core" version="3.1.0" targetFramework="net45" />
+  <package id="System.Reactive.Interfaces" version="3.1.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net45" />
+  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net45" />
+  <package id="System.Reflection.Primitives" version="4.0.1" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net45" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net45" />
+  <package id="System.Runtime.Numerics" version="4.0.1" targetFramework="net45" />
+  <package id="System.Text.Encoding" version="4.0.11" targetFramework="net45" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net45" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net45" />
+  <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The project should now be compatible with:
- .NET 4.5.
- .NET Core 1.0.

Unfortunately, it turns out that Reactive Extensions v2.2.5 is not compatible with .NET Core 1.0. The solution is to update to Reactive Extensions v3.1.0. The NuGet package was renamed to System.Reactive.Core. This requires a minimum of .NET 4.5.