### PR TITLE
Dependencies fix

### DIFF
--- a/NetMQ.ReactiveExtensions/project.json
+++ b/NetMQ.ReactiveExtensions/project.json
@@ -14,6 +14,14 @@
       "dependencies": {
         "System.Xml.Linq": "3.5.*"
       }
+    },
+    "net46": {
+      "dependencies": {
+        
+      },
+      "frameworkAssemblies": {
+        "System.Xml.Linq": "4.0.*"
+      }
     }
   },
   "buildOptions": {


### PR DESCRIPTION
Assuming that .Net Framework 4.5 is to work with Mono I keep
System.Xml.Linq 3.5.* because it seems to be built for that, but it will
force developpers to install .Net Framework 3.5 to make it works. So I
add the System.Xml.Linq 4.0.* to avoid this situation for Microsoft
Visual Studio 2015. Fixed #45